### PR TITLE
Resolves type hinting issue in Media.php

### DIFF
--- a/src/Media.php
+++ b/src/Media.php
@@ -47,7 +47,7 @@ class Media extends Model
      *
      * @throws \Spatie\MediaLibrary\Exceptions\InvalidConversion
      */
-    public function getUrl(string $conversionName = '') : string
+    public function getUrl($conversionName = '') : string
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this);
 
@@ -67,7 +67,7 @@ class Media extends Model
      *
      * @throws \Spatie\MediaLibrary\Exceptions\InvalidConversion
      */
-    public function getPath(string $conversionName = '') : string
+    public function getPath($conversionName = '') : string
     {
         $urlGenerator = UrlGeneratorFactory::createForMedia($this);
 


### PR DESCRIPTION
Previously generating the following errors:
Fatal error: Default value for parameter conversionName with a class type hint can only be NULL in [project root]/vendor/spatie/laravel-medialibrary/src/Media.php on line 50
Fatal error: Default value for parameter conversionName with a class type hint can only be NULL in [project root]/vendor/spatie/laravel-medialibrary/src/Media.php on line 70

Removed the old 'string' type hinting from each method definition
